### PR TITLE
Bump cmake version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 project(cinch)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 #------------------------------------------------------------------------------#
 # Cinch cmake search path and includes


### PR DESCRIPTION
We are using target_include_directories in ProjectLists.txt, which is a cmake-3.0 feature.
