### PR TITLE
Use cmake_minimum_required

### DIFF
--- a/cmake/ProjectLists.txt
+++ b/cmake/ProjectLists.txt
@@ -24,6 +24,7 @@
 #------------------------------------------------------------------------------#
 
 #we are using target_include_directories, which is a cmake-3.0 feature
+cmake_minimum_required(VERSION 3.0)
 set(CINCH_REQUIRED_CMAKE_VERSION 3.0)
 
 if(CMAKE_VERSION VERSION_LESS CINCH_REQUIRED_CMAKE_VERSION)


### PR DESCRIPTION
Without it, I get a warning:

```
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 3.4)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This then causes bunch of other warnings like:

```
CMake Warning (dev) at CMakeLists.txt:165 (if):
  given arguments:

    "True"

  An argument named "True" appears in a conditional statement.  Policy
  CMP0012 is not set: if() recognizes numbers and boolean constants.  Run
  "cmake --help-policy CMP0012" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

And the last warning then causes some if statements to evaluate incorrectly,
thus breaking the build completely. With this patch, the cmake build succeeds
without a single warning and everything works.
