### PR TITLE
add c++11/14 support to Cray Compiler

### DIFF
--- a/cmake/c99.cmake
+++ b/cmake/c99.cmake
@@ -18,7 +18,9 @@ macro(check_for_c99_compiler _VAR)
         (CMAKE_C_COMPILER_ID STREQUAL "PGI" AND
             NOT ${CMAKE_C_COMPILER_VERSION} VERSION_LESS 14.3) OR
         (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND
-            NOT ${CMAKE_C_COMPILER_VERSION} VERSION_LESS 3.1))
+            NOT ${CMAKE_C_COMPILER_VERSION} VERSION_LESS 3.1) OR
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Cray" AND
+            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 8.4))
 
         set(${_VAR} 1)
         message(STATUS "Checking for C99 compiler - available")
@@ -33,9 +35,9 @@ endmacro()
 
 # Sets the appropriate flag to enable C++11 support
 macro(enable_c99)
-    if(NOT CMAKE_C_COMPILER_ID STREQUAL "PGI")
+    if(NOT CMAKE_C_COMPILER_ID STREQUAL "PGI" AND NOT CMAKE_C_COMPILER_ID STREQUAL "Cray" )
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-    endif(NOT CMAKE_C_COMPILER_ID STREQUAL "PGI")
+    endif()
 endmacro()
 
 #~---------------------------------------------------------------------------~-#

--- a/cmake/c99.cmake
+++ b/cmake/c99.cmake
@@ -33,7 +33,7 @@ macro(check_for_c99_compiler _VAR)
 
 endmacro()
 
-# Sets the appropriate flag to enable C++11 support
+# Sets the appropriate flag to enable C99 support
 macro(enable_c99)
     if(NOT CMAKE_C_COMPILER_ID STREQUAL "PGI" AND NOT CMAKE_C_COMPILER_ID STREQUAL "Cray" )
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")

--- a/cmake/cxx11.cmake
+++ b/cmake/cxx11.cmake
@@ -35,13 +35,12 @@ endmacro()
 
 # Sets the appropriate flag to enable C++11 support
 macro(enable_cxx11)
-    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -h std=c++11")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     endif()
-      
 endmacro()
 
 #~---------------------------------------------------------------------------~-#

--- a/cmake/cxx11.cmake
+++ b/cmake/cxx11.cmake
@@ -18,7 +18,9 @@ macro(check_for_cxx11_compiler _VAR)
         (CMAKE_CXX_COMPILER_ID STREQUAL "PGI" AND
             NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 14.3) OR
         (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
-            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.1))
+            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.1) OR
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Cray" AND
+            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 8.4))
 
         set(${_VAR} 1)
         message(STATUS "Checking for C++11 compiler - available")
@@ -33,9 +35,13 @@ endmacro()
 
 # Sets the appropriate flag to enable C++11 support
 macro(enable_cxx11)
-    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -h std=c++11")
+    endif()
+      
 endmacro()
 
 #~---------------------------------------------------------------------------~-#

--- a/cmake/cxx14.cmake
+++ b/cmake/cxx14.cmake
@@ -35,11 +35,11 @@ endmacro()
 
 # Sets the appropriate flag to enable C++14 support
 macro(enable_cxx14)
-    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -h std=c++14")
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     endif()
 endmacro()
 

--- a/cmake/cxx14.cmake
+++ b/cmake/cxx14.cmake
@@ -18,7 +18,9 @@ macro(check_for_cxx14_compiler _VAR)
         (CMAKE_CXX_COMPILER_ID STREQUAL "PGI" AND
             NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 14.3) OR
         (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
-            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.6))
+            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.6) OR
+        (CMAKE_CXX_COMPILER_ID STREQUAL "Cray" AND
+            NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 8.4))
 
         set(${_VAR} 1)
         message(STATUS "Checking for C++14 compiler - available")
@@ -33,9 +35,12 @@ endmacro()
 
 # Sets the appropriate flag to enable C++14 support
 macro(enable_cxx14)
-    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    endif(NOT CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Cray")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -h std=c++14")
+    endif()
 endmacro()
 
 #~---------------------------------------------------------------------------~-#


### PR DESCRIPTION
This change is made for VPIC in preparation for Cray bootcamp.
