### PR TITLE
Add support for OpenMP

### DIFF
--- a/cmake/ProjectLists.txt
+++ b/cmake/ProjectLists.txt
@@ -56,6 +56,7 @@ include(library)
 include(application)
 include(subproject)
 include(doxygen)
+include(openmp)
 include(version)
 
 #------------------------------------------------------------------------------#

--- a/cmake/openmp.cmake
+++ b/cmake/openmp.cmake
@@ -1,0 +1,35 @@
+#------------------------------------------------------------------------------#
+# Copyright (c) 2014 Los Alamos National Security, LLC
+# All rights reserved.
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# Add option to enable OpenMP
+#------------------------------------------------------------------------------#
+
+option(ENABLE_OPENMP "Enable OpenMP" OFF)
+
+if(ENABLE_OPENMP)
+
+#------------------------------------------------------------------------------#
+# Find OpenMP
+#------------------------------------------------------------------------------#
+
+find_package(OpenMP)
+
+#------------------------------------------------------------------------------#
+#------------------------------------------------------------------------------#
+  if(NOT OPENMP_FOUND)
+      message(WARNING "OpenMP was requested but not found.")
+  else()
+    set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+	endif()
+
+endif(ENABLE_OPENMP)
+
+#------------------------------------------------------------------------------#
+# Formatting options for emacs and vim.
+# vim: set tabstop=4 shiftwidth=4 expandtab :
+#------------------------------------------------------------------------------#


### PR DESCRIPTION
Uses cmake's native FindOpenMP to detect the correct compiler flags.  Disabled by default, enable with -DENABLE_OPENMP=on
