### PR TITLE
Disable XML output on MPI ranks other than rank 0

### DIFF
--- a/gtest-auxiliary/gtest-mpi.cc
+++ b/gtest-auxiliary/gtest-mpi.cc
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 #include <mpi.h>
+#include <cstring>
+#include <vector>
 
 #include "listener.h"
 
@@ -12,6 +14,21 @@ int main(int argc, char ** argv) {
 
   // Initialize the MPI runtime
   MPI_Init(&argc, &argv);
+
+  // Disable XML output, if requested, everywhere but rank 0
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::vector<char *> args(argv, argv+argc);
+  if (rank > 0) {
+    for (auto itr = args.begin(); itr != args.end(); ++itr) {
+      if (std::strncmp(*itr, "--gtest_output", 14) == 0) {
+        args.erase(itr);
+        break;
+      }
+    }
+  }
+  argc = args.size();
+  argv = args.data();
 
   // Initialize the GTest runtime
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This avoids a bug in which one rank's XML file overwrites another, leaving an ill-formed XML file in some cases.