### PR TITLE
Added a different logic for MPI_Init* depending on MPI vesion used

### DIFF
--- a/gtest-auxiliary/gtest-mpilegion.cc
+++ b/gtest-auxiliary/gtest-mpilegion.cc
@@ -10,9 +10,26 @@
 
 int main(int argc, char ** argv) {
 
-  // Initialize the MPI runtime
-  MPI_Init(&argc, &argv);
-
+  int version, subversion;
+  MPI_Get_version(&version, &subversion);
+  std::cout <<"MPI version = "<< version<< " , subversion =" << subversion << std::endl;
+//TOFIX:: add check for Gasnet conduit
+  if(version==3 && subversion>0){
+    int provided;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    // If you fail this assertion, then your version of MPI
+    // does not support calls from multiple threads and you 
+    // cannot use the GASNet MPI conduit
+    if (provided < MPI_THREAD_MULTIPLE)
+      printf("ERROR: Your implementation of MPI does not support "
+           "MPI_THREAD_MULTIPLE which is required for use of the "
+           "GASNet MPI conduit with the Legion-MPI Interop!\n");
+    assert(provided == MPI_THREAD_MULTIPLE);
+  }
+  else{
+    // Initialize the MPI runtime
+    MPI_Init(&argc, &argv);
+  }
   // Initialize the GTest runtime
   ::testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
Added a logic for using different MPI_init depending on the MPI version used. MPI_THREAD_MULTIPLE is needed to fix an issue with MPI conduit of GASNet