### PR TITLE
Calling gtest_init() for serial execution

### DIFF
--- a/auxiliary/test-standard.cc
+++ b/auxiliary/test-standard.cc
@@ -30,6 +30,18 @@ void print_devel_code_label(std::string name) {
 } // print_devel_code_label
 #endif
 
+#define _UTIL_STRINGIFY(s) #s
+#define EXPAND_AND_STRINGIFY(s) _UTIL_STRINGIFY(s)
+
+#ifndef GTEST_INIT
+  #include "gtest-init.h"
+#else
+  #include EXPAND_AND_STRINGIFY(GTEST_INIT)
+#endif
+
+#undef EXPAND_AND_STRINGIFY
+#undef _UTIL_STRINGIFY
+
 //----------------------------------------------------------------------------//
 // Main
 //----------------------------------------------------------------------------//
@@ -84,6 +96,9 @@ int main(int argc, char ** argv) {
 
     // Adds a listener to the end.  Google Test takes the ownership.
     listeners.Append(new cinch::listener);
+
+    // Call the user-provided initialization function
+    gtest_init(argc, argv);
 
     // Run the tests for this target.
     result = RUN_ALL_TESTS();


### PR DESCRIPTION
Add calling to the gtest_init() will will in turn calls user defined driver() function.