### PR TITLE
Added the (-DLEGION_CMAKE) definition to the cmake build in purpose t…

### DIFF
--- a/cmake/ProjectLists.txt
+++ b/cmake/ProjectLists.txt
@@ -387,6 +387,7 @@ if(${CINCH_TOP_LEVEL_PROJECT})
 
         # Legion Runtime
         if(Legion_FOUND)
+            add_definitions(-DLEGION_CMAKE)
             cinch_add_test_execution_policy(LEGION
                ${CINCH_SOURCE_DIR}/auxiliary/test-legion.cc
                FLAGS ${Legion_CXX_FLAGS}


### PR DESCRIPTION
Added the (-DLEGION_CMAKE) definition to the cmake build in purpose to be able to get legion_defines.h included in the code. This would be removed when CMake become Legion's main build system