### PR TITLE
Add library target directories to the list of included folders.

### DIFF
--- a/cmake/ProjectLists.txt
+++ b/cmake/ProjectLists.txt
@@ -519,6 +519,7 @@ if(CINCH_LIBRARY_TARGETS)
         # Add the subdirectory
         #----------------------------------------------------------------------#
 
+        include_directories(${library_target_directory})
         add_subdirectory(${library_target_directory})
 
         #----------------------------------------------------------------------#


### PR DESCRIPTION
When a user adds a library target via `cinch_add_library_target(name, dir)`,
add `dir` to the list of include_directories.