### PR TITLE
improved interface to cinch_target_link_libraries

### DIFF
--- a/cmake/library.cmake
+++ b/cmake/library.cmake
@@ -25,12 +25,12 @@ endfunction(cinch_add_library_target)
 # Link libraries to a target
 #
 
-function(cinch_target_link_libraries target libraries)
+function(cinch_target_link_libraries target)
 
-    string(REPLACE ";" "|" libraries_ "${libraries}")
+    string(REPLACE ";" "|" libraries_ "${ARGN}")
 
     message(STATUS
-      "Linking target ${target} with libraries ${libraries}")
+      "Linking target ${target} with libraries ${ARGN}")
 
     list(APPEND CINCH_TARGET_LIBRARIES "${target}:${libraries_}")
     set(CINCH_TARGET_LIBRARIES ${CINCH_TARGET_LIBRARIES} PARENT_SCOPE)


### PR DESCRIPTION
You should just be able to provide a list now, which
is similar to the way `target_link_libraries` works:

    cinch_target_link_libraries( target_name lib1 lib2 lib3 )