### PR TITLE
Suppress MSVC TR1 warnings, tabs --> spaces

### DIFF
--- a/auxiliary/test-standard.cc
+++ b/auxiliary/test-standard.cc
@@ -45,7 +45,7 @@ void print_devel_code_label(std::string name) {
 //----------------------------------------------------------------------------//
 
 int main(int argc, char ** argv) {
-  
+
 #if !defined(CINCH_DEVEL_TARGET)
   // Initialize the GTest runtime
   ::testing::InitGoogleTest(&argc, argv);
@@ -55,7 +55,7 @@ int main(int argc, char ** argv) {
   std::string tags("all");
 
 #if defined(ENABLE_BOOST_PROGRAM_OPTIONS)
-  options_description desc("Cinch test options");  
+  options_description desc("Cinch test options");
 
   // Add command-line options
   desc.add_options()
@@ -73,7 +73,7 @@ if(vm.count("help")) {
   return 1;
 } // if
 #endif // ENABLE_BOOST_PROGRAM_OPTIONS
-	int result(0);
+  int result(0);
 
   if(tags == "0") {
     // Output the available tags
@@ -107,9 +107,9 @@ if(vm.count("help")) {
     // Run the tests for this target.
     result = RUN_ALL_TESTS();
 #endif
-	} // if
+  } // if
 
-	return result;
+  return result;
 } // main
 
 /*~------------------------------------------------------------------------~--*

--- a/cmake/unit.cmake
+++ b/cmake/unit.cmake
@@ -24,10 +24,14 @@ if(ENABLE_UNIT_TESTS)
 
     if(GTEST_FOUND)
         include_directories(${GTEST_INCLUDE_DIRS})
+        if(MSVC)
+          # suppress stupid TR1 warnings issued by MSVC while compiling GTest
+          add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+        endif()
     endif()
-        
+
     if (NOT GTEST_INCLUDE_DIRS)
-        set(GTEST_INCLUDE_DIRS 
+        set(GTEST_INCLUDE_DIRS
           ${CINCH_SOURCE_DIR}/gtest/googlemock/include
           ${CINCH_SOURCE_DIR}/gtest/googletest
           ${CINCH_SOURCE_DIR}/gtest/googletest/include)
@@ -167,8 +171,6 @@ function(cinch_add_unit name)
     # Check to see if the user has specified a runtime and
     # process it
     #--------------------------------------------------------------------------#
-
-    message(cinch_add_unit ${name} ${ARGN} ", unit_POLICY: " ${unit_POLICY})
 
     if(unit_POLICY)
       string(REPLACE "_" ";" unit_policies ${unit_POLICY})


### PR DESCRIPTION
This also removes an accidental change that was merged with #124 
