### PR TITLE
Adding FOLDER support to development targets

### DIFF
--- a/cmake/detail/test-inputs.cmake
+++ b/cmake/detail/test-inputs.cmake
@@ -27,6 +27,11 @@
         add_custom_target(${name}_inputs DEPENDS ${_OUTPUT_FILES})
         add_dependencies(${name} ${name}_inputs)
 
+        if(test_FOLDER)
+            set_target_properties(${name}_inputs
+                PROPERTIES FOLDER "${test_FOLDER}/Inputs")
+        endif()
+
     endif()
 
 #------------------------------------------------------------------------------#

--- a/cmake/detail/test-options.cmake
+++ b/cmake/detail/test-options.cmake
@@ -8,7 +8,7 @@
     #--------------------------------------------------------------------------#
 
     set(options)
-    set(one_value_args POLICY)
+    set(one_value_args POLICY FOLDER)
     set(multi_value_args SOURCES INPUTS THREADS LIBRARIES DEFINES)
 
     cmake_parse_arguments(test "${options}" "${one_value_args}"

--- a/cmake/devel.cmake
+++ b/cmake/devel.cmake
@@ -49,6 +49,10 @@ function(cinch_add_devel_target name)
 
     include(detail/test-inputs)
 
+    if(test_FOLDER)
+        set_target_properties(${name} PROPERTIES FOLDER "${test_FOLDER}")
+    endif()
+
 endfunction(cinch_add_devel_target)
 
 #------------------------------------------------------------------------------#

--- a/cmake/hpx.cmake
+++ b/cmake/hpx.cmake
@@ -28,6 +28,7 @@ if(ENABLE_HPX)
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
     add_definitions(-D_HAS_AUTO_PTR_ETC=1)
+    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
   endif()
 
   message(STATUS "HPX found: ${HPX_FOUND}")

--- a/cmake/unit.cmake
+++ b/cmake/unit.cmake
@@ -47,6 +47,10 @@ if(ENABLE_UNIT_TESTS)
         target_link_libraries(gtest ${CMAKE_THREAD_LIBS_INIT})
         target_include_directories(gtest PRIVATE ${GTEST_INCLUDE_DIRS})
         set_target_properties(gtest PROPERTIES FOLDER "Dependencies")
+        if(BUILD_SHARED_LIBS)
+            set_target_properties(gtest PROPERTIES
+                COMPILE_DEFINITIONS "GTEST_CREATE_SHARED_LIBRARY=1")
+        endif()
     endif()
 
     #--------------------------------------------------------------------------#


### PR DESCRIPTION
- flyby: globally suppressing stupid TR1 MSVC warning
- flyby: ensure gtest is build as a shared library