### PR TITLE
Making sure development targets are properly built against HPX

### DIFF
--- a/cmake/detail/test-policies.cmake
+++ b/cmake/detail/test-policies.cmake
@@ -38,9 +38,12 @@
     elseif(MPI_${MPI_LANGUAGE}_FOUND AND HPX_FOUND AND test_POLICY STREQUAL "HPX")
 
         set(test_policy_runtime ${CINCH_SOURCE_DIR}/auxiliary/test-hpx.cc)
-        set(test_policy_flags ${MPI_${MPI_LANGUAGE}_COMPILE_FLAGS})
-        set(test_policy_includes ${MPI_${MPI_LANGUAGE}_INCLUDE_PATH})
-        set(test_policy_libraries ${MPI_${MPI_LANGUAGE}_LIBRARIES})
+        set(test_policy_flags ${MPI_${MPI_LANGUAGE}_COMPILE_FLAGS}
+            ${HPX_CXX_FLAGS})
+        set(test_policy_includes ${MPI_${MPI_LANGUAGE}_INCLUDE_PATH}
+            ${HPX_INCLUDE_DIRS})
+        set(test_policy_libraries ${MPI_${MPI_LANGUAGE}_LIBRARIES}
+            ${HPX_LIBRARIES} ${HPX_LIB_FLAGS})
         set(test_policy_exec ${MPIEXEC})
         set(test_policy_exec_threads ${MPIEXEC_NUMPROC_FLAG})
         set(test_policy_defines -DCINCH_ENABLE_MPI)

--- a/cmake/detail/test-properties.cmake
+++ b/cmake/detail/test-properties.cmake
@@ -63,6 +63,9 @@
         target_link_libraries(${name} ${test_LIBRARIES})
     endif()
 
+    if (HPX_FOUND AND test_POLICY STREQUAL "HPX")
+        hpx_setup_target(${name} NOPREFIX)
+    endif()
 #------------------------------------------------------------------------------#
 # Formatting options for emacs and vim.
 # vim: set tabstop=4 shiftwidth=4 expandtab :


### PR DESCRIPTION
This is in support of the HPX backend that is currently being developed