### PR TITLE
remove v prefix from Cinch version so that version comparison works correctly

### DIFF
--- a/cmake/cinch_minimum_required.cmake
+++ b/cmake/cinch_minimum_required.cmake
@@ -27,8 +27,12 @@ function(cinch_minimum_required)
         string(STRIP "${CINCH_VERSION}" CINCH_VERSION)
     endif()
 
+    # remove v prefix from the version so that CMake can compare the version
+    # number
+    string(REGEX REPLACE "^v" "" CINCH_VERSION ${CINCH_VERSION})
+
     if(CINCH_VERSION VERSION_LESS ${_cinch_VERSION})
-        message(FATAL_ERROR "${PROJECT_NAME} requries Cinch "
+        message(FATAL_ERROR "${PROJECT_NAME} requires Cinch "
             "version ${_cinch_VERSION} (found version ${CINCH_VERSION})"
         )
     else()


### PR DESCRIPTION
Right now I keep getting
```
CMake Error at cinch/cmake/cinch_minimum_required.cmake:31 (message):
  Project requries Cinch version 1.0 (found version v2.0)
Call Stack (most recent call first):
  config/project.cmake:19 (cinch_minimum_required)
  cinch/cmake/ProjectLists.txt:45 (include)
  CMakeLists.txt:41 (include)
```
when I try to build FleCSI.