### PR TITLE
Adapt to latest HPX changes

### DIFF
--- a/cmake/detail/test-properties.cmake
+++ b/cmake/detail/test-properties.cmake
@@ -64,7 +64,7 @@
     endif()
 
     if (HPX_FOUND AND test_POLICY STREQUAL "HPX")
-        hpx_setup_target(${name} NOPREFIX)
+        hpx_setup_target(${name} NOPREFIX NOTLLKEYWORD)
     endif()
 #------------------------------------------------------------------------------#
 # Formatting options for emacs and vim.


### PR DESCRIPTION
Latest HPX build system relies on specifying target keywords to target_link_library by default. This fix instructs HPX not to do that.