### PR TITLE
Fixed Install path for Cinch Logger

### DIFF
--- a/cmake/logging.cmake
+++ b/cmake/logging.cmake
@@ -8,7 +8,7 @@ include_directories(${CINCH_SOURCE_DIR}/logging)
 # Install cinch logging utility
 #--------------------------------------------------------------------------#
 
-install(FILES ${CMAKE_SOURCE_DIR}/cinch/logging/cinchlog.h
+install(FILES ${CINCH_SOURCE_DIR}/logging/cinchlog.h
     DESTINATION include)
 
 option(ENABLE_CLOG "Enable Cinch logging" OFF)


### PR DESCRIPTION
Fixed install path for cinch logger to support flecsi builds with an
external cinch (via ${CINCH_SOURCE_DIR}) or any project that does not have cinch as a top level directory.